### PR TITLE
Stop single-node by pressing Ctrl+C in terminal

### DIFF
--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -35,18 +35,26 @@ serverurl=unix:///var/run/cusdeb-supervisor.sock    ; use a unix:// URL  for a u
 [program:bm]
 autorestart=false
 command=run_bm.sh
+stopsignal=KILL
+stopasgroup=true
 
 [program:dashboard_client]
 autorestart=false
 command=run_dashboard_client.sh
+stopsignal=KILL
+stopasgroup=true
 
 [program:dashboard_server]
 autorestart=false
 command=run_dashboard_server.sh
+stopsignal=KILL
+stopasgroup=true
 
 [program:dominion]
 autorestart=false
 command=run_dominion.sh
+stopsignal=KILL
+stopasgroup=true
 
 [program:worker]
 command=run_worker.sh
@@ -70,4 +78,3 @@ killasgroup=true
 ; Set Celery priority higher than default (999)
 ; so, if rabbitmq is supervised, it will start first.
 priority=1000
-

--- a/functions.sh
+++ b/functions.sh
@@ -243,6 +243,24 @@ stop_containers() {
     done
 }
 
+run_daemons() {
+    echo PATH="${TARGET}/dominion-dev/bin:$(pwd)"/runners:"${PATH}"
+    env PATH="${TARGET}/dominion-dev/bin:$(pwd)"/runners:"${PATH}" supervisord -c config/supervisord.conf
+}
+
+stop_daemons() {
+    for pid in $(sudo supervisorctl -c ./config/supervisord.conf pid all); do
+        # If a process is stopped, supervisorctl shows that the pid of the
+        # process is 0. It's not what we need.
+        if [[ "${pid}" > 0 ]]; then
+            info "killing ${pid}"
+            kill -9 -"${pid}"
+        fi
+    done
+
+    kill -9 "$(sudo supervisorctl -c ./config/supervisord.conf pid)"
+}
+
 switch_state_to() {
     local state=$1
 

--- a/single-node.sh
+++ b/single-node.sh
@@ -366,23 +366,15 @@ start)
     check_ports
 
     run_containers
+    trap "stop_containers && exit 130" 2
 
-    env PATH="${TARGET}/dominion-dev/bin:$(pwd)"/runners:"${PATH}" supervisord -c config/supervisord.conf
+    run_daemons
 
     ;;
 stop)
     stop_containers
 
-    for pid in $(sudo supervisorctl -c ./config/supervisord.conf pid all); do
-        # If a process is stopped, supervisorctl shows that the pid of the
-        # process is 0. It's not what we need.
-        if [[ "${pid}" > 0 ]]; then
-            info "killing ${pid}"
-            kill -9 -"${pid}"
-        fi
-    done
-
-    kill -9 "$(sudo supervisorctl -c ./config/supervisord.conf pid)"
+    stop_daemons
 
     ;;
 *)


### PR DESCRIPTION
Closes #6. 
Use this as a reference for supervisor changes https://coderwall.com/p/4tcw7w/setting-supervisor-to-really-stop-django-runserver