### PR TITLE
Do not check if 8000 is occupied

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -57,7 +57,6 @@ check_if_cusdeb_single_node_is_installed() {
 
 check_ports() {
     local ports=(
-        ${PROXY_PORT}
         ${DASHBOARD_PORT}
         ${BM_PORT}
         ${DOMINION_PORT}

--- a/single-node.sh
+++ b/single-node.sh
@@ -39,8 +39,6 @@ set -x
 
 export HOST=${HOST:=localhost}
 
-export PROXY_PORT=${PROXY_PORT:=8000}
-
 export DASHBOARD_PORT=${DASHBOARD_PORT:=8001}
 
 export DJANGO_CONFIGURATION=${DJANGO_CONFIGURATION:=Docker}


### PR DESCRIPTION
Port `8000` is not occupied by any CusDeb service, so there is no need to check it.