### PR TITLE
Fix stop command

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -514,7 +514,7 @@ run_daemons() {
 }
 
 stop_daemons() {
-    for pid in $(sudo supervisorctl -c ./config/supervisord.conf pid all); do
+    for pid in $(supervisorctl -c ./config/supervisord.conf pid all); do
         # If a process is stopped, supervisorctl shows that the pid of the
         # process is 0. It's not what we need.
         if [[ "${pid}" -gt 0 ]]; then
@@ -523,7 +523,7 @@ stop_daemons() {
         fi
     done
 
-    kill -9 "$(sudo supervisorctl -c ./config/supervisord.conf pid)"
+    kill -9 "$(supervisorctl -c ./config/supervisord.conf pid)"
 }
 
 switch_state_to() {

--- a/single-node.sh
+++ b/single-node.sh
@@ -240,7 +240,12 @@ start)
 
     ;;
 stop)
+    check_if_cusdeb_single_node_is_installed
+
     stop_containers
+
+    TARGET="$(cat cusdeb)"
+    export TARGET
 
     stop_daemons
 


### PR DESCRIPTION
There is the following problem when running `sudo ./single-node.sh stop`:

```
Error: Format string 'unix://%(ENV_TARGET)s/cusdeb-supervisor.sock' for 'supervisorctl.serverurl' contains names ('ENV_TARGET') which cannot be expanded. Available names: ENV_COLORTERM, ENV_DISPLAY, ENV_HOME, ENV_LANG, ENV_LANGUAGE, ENV_LC_ADDRESS, ENV_LC_IDENTIFICATION, ENV_LC_MEASUREMENT, ENV_LC_MONETARY, ENV_LC_NAME, ENV_LC_NUMERIC, ENV_LC_PAPER, ENV_LC_TELEPHONE, ENV_LC_TIME, ENV_LOGNAME, ENV_LS_COLORS, ENV_MAIL, ENV_PATH, ENV_SHELL, ENV_SUDO_COMMAND, ENV_SUDO_GID, ENV_SUDO_UID, ENV_SUDO_USER, ENV_TERM, ENV_USER, ENV_USERNAME, ENV_XAUTHORITY, here
For help, use /usr/bin/supervisorctl -h
Error: Format string 'unix://%(ENV_TARGET)s/cusdeb-supervisor.sock' for 'supervisorctl.serverurl' contains names ('ENV_TARGET') which cannot be expanded. Available names: ENV_COLORTERM, ENV_DISPLAY, ENV_HOME, ENV_LANG, ENV_LANGUAGE, ENV_LC_ADDRESS, ENV_LC_IDENTIFICATION, ENV_LC_MEASUREMENT, ENV_LC_MONETARY, ENV_LC_NAME, ENV_LC_NUMERIC, ENV_LC_PAPER, ENV_LC_TELEPHONE, ENV_LC_TIME, ENV_LOGNAME, ENV_LS_COLORS, ENV_MAIL, ENV_PATH, ENV_SHELL, ENV_SUDO_COMMAND, ENV_SUDO_GID, ENV_SUDO_UID, ENV_SUDO_USER, ENV_TERM, ENV_USER, ENV_USERNAME, ENV_XAUTHORITY, here
For help, use /usr/bin/supervisorctl -h
./functions.sh: line 526: kill: `': not a pid or valid job spec
``` 