### PR TITLE
Allow unauthenticated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
     - debian-sid
 
 before_install:
-  - sudo apt-get install -y shellcheck
+  - sudo apt-get install -y --allow-unauthenticated shellcheck
 
 script:
   - bash -c 'find . -type f -name "*.sh" | xargs shellcheck -e SC2148,SC2164 -x'


### PR DESCRIPTION
It helps to solve the following new problem:
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
The command "sudo apt-get install -y bash pandoc shellcheck shunit2" failed and exited with 100 during .