### PR TITLE
Remove compilemessages parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Script supports the following parameters:
 | Parameter    | Description |
 |------------|---------|
 | build `<target_directory>` | Setup all CusDeb services with all dependences to the `<target_directory>`. It supposed to be empty.
-| compilemessages        | Comlipe `.po` files to `.mo` files (see the corresponding [section](https://docs.djangoproject.com/en/2.2/ref/django-admin/#compilemessages) in the official documentation).
 | create-superuser       | Create superuser for Django admin interface (see the corresponding [section](https://docs.djangoproject.com/en/2.2/ref/django-admin/#createsuperuser) in the official documentation).
 | dbshell                | Connect to the project's database (see the corresponding [section](https://docs.djangoproject.com/en/2.2/ref/django-admin/#dbshell) in the official documentation).
 | loaddata `<fixture>`   | Read the data from the specified fixture and load it into the database (note that `<fixture>` must be a full path to the fixture file) (see the corresponding [section](https://docs.djangoproject.com/en/2.2/ref/django-admin/#loaddata) in the official documentation).

--- a/single-node.sh
+++ b/single-node.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-USAGE="USAGE: $0 build <target directory>|compilemessages|create-superuser|dbshell|loaddata|makemessages|makemigrations|migrate|rebuild|remove|restart|shell <service>|start|stop"
+USAGE="USAGE: $0 build <target directory>|create-superuser|dbshell|loaddata|makemessages|makemigrations|migrate|rebuild|remove|restart|shell <service>|start|stop"
 
 if [ -z "$1" ]; then
     >&2 echo "${USAGE}"
@@ -158,10 +158,6 @@ rebuild)
     esac
 
     build_env "$state" "$recipe"
-
-    ;;
-compilemessages)
-    run_manage_py compilemessages -l ru
 
     ;;
 create-superuser)


### PR DESCRIPTION
* cusdeb-api doesn't deal with l10n, so remove the `compilemessages` parameter.
* Close #29 since `compilemessages` is removed by accepting this PR.